### PR TITLE
Make some mini iframes higher, to avoid cutting off content

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,12 +70,12 @@
 			“I wanna move if less than 1/3 of my neighbors are like me.”
 			</b>
 		</p>
-		<iframe playable src="play/mini/mini_unhappy.html" width="250" height="300" scrolling="no" style="float:left; margin:0; margin-left:10px; position:relative; left:-30px"  embedded></iframe>
-		<iframe playable src="play/mini/mini_happy.html" width="250" height="300" scrolling="no" style="float:left; margin:0; margin-left:10px"  embedded></iframe>
-		<iframe playable src="play/mini/mini_bored.html" width="250" height="300" scrolling="no" style="float:left; margin:0; margin-left:10px; position:relative; left:30px"  embedded></iframe>
+		<iframe playable src="play/mini/mini_unhappy.html" width="250" height="320" scrolling="no" style="float:left; margin:0; margin-left:10px; position:relative; left:-30px"  embedded></iframe>
+		<iframe playable src="play/mini/mini_happy.html" width="250" height="320" scrolling="no" style="float:left; margin:0; margin-left:10px"  embedded></iframe>
+		<iframe playable src="play/mini/mini_bored.html" width="250" height="320" scrolling="no" style="float:left; margin:0; margin-left:10px; position:relative; left:30px"  embedded></iframe>
 		<div style="clear:both;height: 0;position: relative;">
-			<div style="width: 4px; height: 290px; background: #bbb;position: absolute;top: -292px;left: 245px;"></div>
-			<div style="width: 4px; height: 290px; background: #bbb;position: absolute;top: -292px;left: 537px;"></div>
+			<div style="width: 4px; height: 310px; background: #bbb;position: absolute;top: -312px;left: 245px;"></div>
+			<div style="width: 4px; height: 310px; background: #bbb;position: absolute;top: -312px;left: 537px;"></div>
 		</div>
 		<br>
 
@@ -161,10 +161,10 @@
 			Seems reasonable for a shape to prefer not being in the minority...
 		</p>
 		
-		<iframe id="mini_bias_1" playable src="play/mini/mini_bias_1.html" width="310" height="420" scrolling="no" style="float:left; margin:0; margin-left:50px" embedded></iframe>
-		<iframe id="mini_bias_2" playable src="play/mini/mini_bias_2.html" width="310" height="420" scrolling="no" style="float:right; margin:0; margin-right:50px" embedded></iframe>
+		<iframe id="mini_bias_1" playable src="play/mini/mini_bias_1.html" width="310" height="440" scrolling="no" style="float:left; margin:0; margin-left:50px" embedded></iframe>
+		<iframe id="mini_bias_2" playable src="play/mini/mini_bias_2.html" width="310" height="440" scrolling="no" style="float:right; margin:0; margin-right:50px" embedded></iframe>
 		<div style="clear:both;height: 0;position: relative;">
-			<div style="width: 6px; height: 400px; background: #bbb;position: absolute;top: -420px;left: 397px;"></div>
+			<div style="width: 6px; height: 420px; background: #bbb;position: absolute;top: -440px;left: 397px;"></div>
 		</div>
 
 		<p>


### PR DESCRIPTION
On my machine (Linux, Firefox 34.0.5), two mini iframe groups look like this:

![cutoff](https://cloud.githubusercontent.com/assets/81277/5343632/09740c90-7f08-11e4-945e-3c44a82b61d2.png)

I figure this is a font issue, where you had access to different fonts which fit the texts in two lines. Since I think the additional white space on machines where the text indeed is in two lines can't hurt, I made this small modification. Please see whether or not it is useful.

I explicitly agree to the CC-0 license for my contribution :-D
