### PR TITLE
Remove Ada Initiative from list of donatees, closed in 2015

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,9 +351,6 @@
 					<a target="_blank" href="http://codeliberation.org/">Code Liberation</a>
 					- free workshops to help women make videogames
 					<br>
-					<a target="_blank" href="http://adainitiative.org/">Ada Initiative</a>
-					- supports women in open source &amp; open culture
-					<br>
 					<a target="_blank" href="http://www.patreon.com/ncase">Nicky's Patreon</a>
 					- makes public domain playables (such as this one!)
 


### PR DESCRIPTION
The Ada Initiative (which I co-founded) closed 18 months ago. We're not a good recommendation for donations.

See https://adainitiative.org/2015/08/04/announcing-the-shutdown-of-the-ada-initiative/